### PR TITLE
Update TachiTess.shader

### DIFF
--- a/TachiTess.shader
+++ b/TachiTess.shader
@@ -84,5 +84,5 @@ Shader "Tachi/Tess" {
         ENDCG
     }
 
-    FallBack "Diffuse"
+    FallBack "Standard"
 }


### PR DESCRIPTION
Changing the fallback to Standard will fix the alpha/transparency issue. Unity's Diffuse shader isn't built into VRChat so it can't be used as a fallback.